### PR TITLE
SSL cert checking via CLI option

### DIFF
--- a/pytest_testrail/conftest.py
+++ b/pytest_testrail/conftest.py
@@ -10,6 +10,12 @@ def pytest_addoption(parser):
         '--testrail',
         action='store',
         help='Create and update testruns with TestRail')
+    group.addoption(
+        '--no-ssl-cert-check',
+        action='store_true',
+        default=False,
+        required=False,
+    )
 
 
 def pytest_configure(config):
@@ -18,13 +24,18 @@ def pytest_configure(config):
         client = APIClient(cfg_file.get('API', 'url'))
         client.user = cfg_file.get('API', 'email')
         client.password = cfg_file.get('API', 'password')
+        ssl_cert_check = True
+
+        if config.getoption("--no-ssl-cert-check") is True:
+            ssl_cert_check = False
 
         config.pluginmanager.register(
             TestRailPlugin(
                 client,
                 cfg_file.get('TESTRUN', 'assignedto_id'),
                 cfg_file.get('TESTRUN', 'project_id'),
-                cfg_file.get('TESTRUN', 'suite_id')
+                cfg_file.get('TESTRUN', 'suite_id'),
+                ssl_cert_check
             )
         )
 

--- a/pytest_testrail/conftest.py
+++ b/pytest_testrail/conftest.py
@@ -15,6 +15,7 @@ def pytest_addoption(parser):
         action='store_true',
         default=False,
         required=False,
+        help='Do not check for valid SSL certificate on TestRail host'
     )
 
 

--- a/pytest_testrail/plugin.py
+++ b/pytest_testrail/plugin.py
@@ -100,7 +100,8 @@ class TestRailPlugin(object):
             if rep.when == 'call' and testcaseids:
                 self.add_result(
                     clean_test_ids(testcaseids),
-                    get_test_outcome(outcome.result.outcome))
+                    get_test_outcome(outcome.result.outcome)
+                )
 
     def pytest_sessionfinish(self, session, exitstatus):
         data = {'results': self.results}

--- a/pytest_testrail/plugin.py
+++ b/pytest_testrail/plugin.py
@@ -34,7 +34,7 @@ def get_test_outcome(outcome):
     :param str outcome: pytest reported test outcome value.
     :returns: int relating to test outcome.
     """
-    return PYTEST_TO_TESTRAIL_STATUS[outcome] if outcome == 'failed' else PYTEST_TO_TESTRAIL_STATUS[outcome]
+    return PYTEST_TO_TESTRAIL_STATUS[outcome]
 
 
 def testrun_name():
@@ -68,13 +68,14 @@ def get_testrail_keys(items):
 
 class TestRailPlugin(object):
 
-    def __init__(self, client, assign_user_id, project_id, suite_id):
+    def __init__(self, client, assign_user_id, project_id, suite_id, cert_chk):
         self.client = client
         self.assign_user_id = assign_user_id
         self.project_id = project_id
         self.suite_id = suite_id
         self.testrun_id = 0
         self.results = []
+        self.cert_check = cert_chk
 
     # pytest hooks
 
@@ -102,7 +103,11 @@ class TestRailPlugin(object):
     def pytest_sessionfinish(self, session, exitstatus):
         data = {'results': self.results}
         if data['results']:
-            self.client.send_post(ADD_RESULTS_URL.format(self.testrun_id), data)
+            self.client.send_post(
+                ADD_RESULTS_URL.format(self.testrun_id),
+                data,
+                self.cert_check
+            )
 
     # plugin
 
@@ -134,5 +139,10 @@ class TestRailPlugin(object):
             'case_ids': tr_keys,
         }
 
-        response = self.client.send_post(ADD_TESTRUN_URL.format(project_id), data)
+        response = self.client.send_post(
+            ADD_TESTRUN_URL.format(project_id),
+            data,
+            self.cert_check
+        )
+
         self.testrun_id = response['id']

--- a/pytest_testrail/plugin.py
+++ b/pytest_testrail/plugin.py
@@ -67,15 +67,15 @@ def get_testrail_keys(items):
 
 
 class TestRailPlugin(object):
-
-    def __init__(self, client, assign_user_id, project_id, suite_id, cert_chk):
+    def __init__(
+            self, client, assign_user_id, project_id, suite_id, cert_check):
         self.client = client
         self.assign_user_id = assign_user_id
         self.project_id = project_id
         self.suite_id = suite_id
         self.testrun_id = 0
         self.results = []
-        self.cert_check = cert_chk
+        self.cert_check = cert_check
 
     # pytest hooks
 
@@ -98,7 +98,9 @@ class TestRailPlugin(object):
             testcaseids = item.get_marker(TESTRAIL_PREFIX).kwargs.get('ids')
 
             if rep.when == 'call' and testcaseids:
-                self.add_result(clean_test_ids(testcaseids), get_test_outcome(outcome.result.outcome))
+                self.add_result(
+                    clean_test_ids(testcaseids),
+                    get_test_outcome(outcome.result.outcome))
 
     def pytest_sessionfinish(self, session, exitstatus):
         data = {'results': self.results}
@@ -125,7 +127,8 @@ class TestRailPlugin(object):
             }
             self.results.append(data)
 
-    def create_test_run(self, assign_user_id, project_id, suite_id, testrun_name, tr_keys):
+    def create_test_run(
+            self, assign_user_id, project_id, suite_id, testrun_name, tr_keys):
         """
         Create testrun with ids collected from markers.
 

--- a/pytest_testrail/testrail_api.py
+++ b/pytest_testrail/testrail_api.py
@@ -34,19 +34,15 @@ class APIClient:
     # uri                 The API method to call including parameters
     #                     (e.g. get_case/1)
     #
-    def send_get(self, uri):
+    def send_get(self, uri, cert_check):
         url = self.__url + uri
-        e = None
-
-        try:
-            r = requests.get(
-                url,
-                auth=(self.user, self.password),
-                headers=self.headers
-            )
-            return r.json()
-        except requests.RequestException as e:
-            return e.response.text()
+        r = requests.get(
+            url,
+            auth=(self.user, self.password),
+            headers=self.headers,
+            verify=cert_check
+        )
+        return r.json()
 
     #
     # Send POST
@@ -61,17 +57,13 @@ class APIClient:
     # data                The data to submit as part of the request (as
     #                     Python dict, strings must be UTF-8 encoded)
     #
-    def send_post(self, uri, data):
+    def send_post(self, uri, data, cert_check):
         url = self.__url + uri
-        e = None
-
-        try:
-            r = requests.post(
-                url,
-                auth=(self.user, self.password),
-                headers=self.headers,
-                data=json.dumps(data)
-            )
-            return r.json()
-        except requests.RequestException as e:
-            return e.response.text()
+        r = requests.post(
+            url,
+            auth=(self.user, self.password),
+            headers=self.headers,
+            data=json.dumps(data),
+            verify=cert_check
+        )
+        return r.json()

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     name='pytest-testrail',
     description='pytest plugin for creating TestRail runs and adding results',
     long_description=long_description,
-    version='0.0.7',
+    version='0.0.8',
     author='Allan Kilpatrick',
     author_email='allanklp@gmail.com',
     url='http://github.com/allankilpatrick/pytest-testrail/',

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -29,8 +29,7 @@ def api_client():
 
 @pytest.fixture
 def tr_plugin(api_client):
-    return TestRailPlugin(
-        api_client, ASSIGN_USER_ID, PROJECT_ID, SUITE_ID, True)
+    return TestRailPlugin(api_client, ASSIGN_USER_ID, PROJECT_ID, SUITE_ID, True)
 
 
 @pytest.fixture
@@ -41,13 +40,11 @@ def pytest_test_items(testdir):
 
 @freeze_time(FAKE_NOW)
 def test_testrun_name():
-    run_time = FAKE_NOW.strftime(plugin.DT_FORMAT)
-    assert plugin.testrun_name() == 'Automated Run {}'.format(run_time)
+    assert plugin.testrun_name() == 'Automated Run {}'.format(FAKE_NOW.strftime(plugin.DT_FORMAT))
 
 
 def test_failed_outcome(tr_plugin):
-    failed_outcome = plugin.PYTEST_TO_TESTRAIL_STATUS['failed']
-    assert plugin.get_test_outcome('failed') == failed_outcome
+    assert plugin.get_test_outcome('failed') == plugin.PYTEST_TO_TESTRAIL_STATUS['failed']
 
 
 def test_successful_outcome(tr_plugin):
@@ -82,9 +79,7 @@ def test_add_result(tr_plugin):
 
 def pytest_runtest_makereport(pytest_test_items, tr_plugin):
     keys = ['C4354', 'C1234']
-    report = Mock(
-        keywords={key: None for key in keys},
-        failed=True, when='teardown')
+    report = Mock(keywords={key: None for key in keys}, failed=True, when='teardown')
 
     tr_plugin.pytest_runtest_makereport(report)
 
@@ -111,19 +106,14 @@ def test_pytest_sessionfinish(api_client, tr_plugin):
     expected_uri = plugin.ADD_RESULTS_URL.format(10)
     expected_data = {'results': [1, 2]}
     check_cert = True
-    api_client.send_post.assert_called_once_with(
-        expected_uri,
-        expected_data,
-        check_cert
-    )
+    api_client.send_post.assert_called_once_with(expected_uri, expected_data, check_cert)
 
 
 def test_create_test_run(api_client, tr_plugin):
     expected_tr_keys = [3453, 234234, 12]
     expect_name = 'testrun_name'
 
-    tr_plugin.create_test_run(
-        ASSIGN_USER_ID, PROJECT_ID, SUITE_ID, expect_name, expected_tr_keys)
+    tr_plugin.create_test_run(ASSIGN_USER_ID, PROJECT_ID, SUITE_ID, expect_name, expected_tr_keys)
 
     expected_uri = plugin.ADD_TESTRUN_URL.format(PROJECT_ID)
     expected_data = {
@@ -134,7 +124,4 @@ def test_create_test_run(api_client, tr_plugin):
         'case_ids': expected_tr_keys
     }
     check_cert = True
-    api_client.send_post.assert_called_once_with(
-        expected_uri,
-        expected_data, check_cert
-    )
+    api_client.send_post.assert_called_once_with(expected_uri, expected_data, check_cert)


### PR DESCRIPTION
The instance of TestRail we are currently using at Mozilla doesn't have an SSL certificate that the Requests library considers valid. At some point we'll fix that issue but in order for the plugin to work for as I modified the code at accept a '--no-ssl-cert-check' CLI option that will in turn set verify=False when the Requests makes a post.

By default --no-ssl-cert-check is set to False, and I have code that inverts the value so that verify=True will be the default.

I also removed the try-catch stuff around send_post and send_get after discovering trapping exceptions probably isn't good behaviour -- can't do POSTs using verify=false. ;)

Version is bumped to 0.0.8

@allankilpatrick r?