### PR TITLE
Password interpolation fix

### DIFF
--- a/pytest_testrail/conftest.py
+++ b/pytest_testrail/conftest.py
@@ -31,7 +31,7 @@ def pytest_configure(config):
         cfg_file = read_config_file(config.getoption("--testrail"))
         client = APIClient(cfg_file.get('API', 'url'))
         client.user = cfg_file.get('API', 'email')
-        client.password = cfg_file.get('API', 'password')
+        client.password = cfg_file.get('API', 'password', raw=True)
         ssl_cert_check = True
         tr_name = config.getoption('--tr_name')
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     name='pytest-testrail',
     description='pytest plugin for creating TestRail runs and adding results',
     long_description=long_description,
-    version='0.0.10',
+    version='0.0.11',
     author='Allan Kilpatrick',
     author_email='allanklp@gmail.com',
     url='http://github.com/allankilpatrick/pytest-testrail/',


### PR DESCRIPTION
The configparser code was choking on Testrail passwords that contained '%' sign, spitting out string interpolation errors. The code that reads in the password from the configuration file has been changed to set raw=True to fix this problem. Also bumped the version number.

@allankilpatrick r?